### PR TITLE
Fix deprecation warnings

### DIFF
--- a/lib/App/Mowyw.pm
+++ b/lib/App/Mowyw.pm
@@ -72,8 +72,8 @@ my @input_tokens = (
             )/x                         ],
         [ 'TAG_END',        qr/\s*\]\]\]/],
         [ 'TAG_END',        qr/\s*\%\]/],
-        [ 'BRACES_START',   qr/{{/],
-        [ 'BRACES_END',     qr/}}/],
+        [ 'BRACES_START',   qr/\{\{/],
+        [ 'BRACES_END',     qr/\}\}/],
     );
 
 sub parse_all_in_dir {


### PR DESCRIPTION
See [CPAN RT#107510](https://rt.cpan.org/Public/Bug/Display.html?id=107510).

```
Unescaped left brace in regex is deprecated, passed through in regex; marked by <-- HERE in m/\G((?^:{{ <-- HERE ))/ at E:\Dokumenty\git\mowyw\blib\lib/App/Mowyw/Lexer.pm line 90.
```
